### PR TITLE
add "GNOME Apps" section

### DIFF
--- a/.vitepress/config/en.ts
+++ b/.vitepress/config/en.ts
@@ -67,6 +67,12 @@ export const en = defineConfigWithTheme({
             baseUrl: '//flathub.org/apps/',
             style: '--agw-btn-bg: var(--vp-c-blue-dimm-1); --agw-btn-color: var(--vp-c-blue-darker); --agw-btn-hover-bg:var(--vp-c-blue-dark); --agw-btn-hover-color: var(--vp-c-white);'
           },
+          about_app: {
+            anchor: 'More',
+            target: '_blank',
+            style:
+              '--agw-btn-bg: var(--vp-c-green-dimm-1); --agw-btn-color: var(--vp-c-green-darker); --agw-btn-hover-bg:var(--vp-c-green-dark); --agw-btn-hover-color: var(--vp-c-white);'
+          }
         }
       }
     },

--- a/.vitepress/config/ru.ts
+++ b/.vitepress/config/ru.ts
@@ -85,6 +85,12 @@ export const ru = defineConfigWithTheme({
                     target: '_blank',
                     baseUrl: '//flathub.org/ru/apps/',
                     style: '--agw-btn-bg: var(--vp-c-blue-dimm-1); --agw-btn-color: var(--vp-c-blue-darker); --agw-btn-hover-bg:var(--vp-c-blue-dark); --agw-btn-hover-color: var(--vp-c-white);'
+                },
+                about_app: {
+                  anchor: 'Подробнее',
+                  target: '_blank',
+                  style:
+                    '--agw-btn-bg: var(--vp-c-green-dimm-1); --agw-btn-color: var(--vp-c-green-darker); --agw-btn-hover-bg:var(--vp-c-green-dark); --agw-btn-hover-color: var(--vp-c-white);'
                 }
             }
         }

--- a/.vitepress/data/navigations.ts
+++ b/.vitepress/data/navigations.ts
@@ -2,6 +2,7 @@ export const nav = {
     'root': [
         { text: 'Главная', link: '/' },
         { text: 'Документация', link: '/wiki/' },
+        { text: 'Приложения GNOME', link: '/system/apps-gnome/' },
         {
             text: 'О проекте', items: [
                 { text: 'О проекте', link: '/projects/about/' },
@@ -12,6 +13,7 @@ export const nav = {
     'en': [
         { text: 'Home', link: '/en/' },
         { text: 'Documentation', link: '/en/wiki/' },
+        { text: 'GNOME Apps', link: '/en/system/apps-gnome/' },
         {
             text: 'About project', items: [
                 { text: 'About project', link: '/en/projects/about/' },

--- a/.vitepress/data/team.ts
+++ b/.vitepress/data/team.ts
@@ -38,6 +38,13 @@ export const contributions = [
     ]
   },
   {
+    avatar: 'https://avatars.githubusercontent.com/u/44705058?v=4',
+    name: 'Антон Политов',
+    mapByNameAliases: ['Ampernic', 'Антон Политов', 'Anton Politov', 'ampernic'],
+    title: 'Разработчик, Участник',
+    links: [{ icon: 'github', link: 'https://github.com/Ampernic' }]
+  },
+  {
     avatar: 'https://avatars.githubusercontent.com/u/57626821?v=4',
     name: 'Семен Фомченков',
     mapByNameAliases: ['Semen Fomchenkov', 'Armatik', 'armatik'],

--- a/.vitepress/theme/components/AMWAsideMetaLink.vue
+++ b/.vitepress/theme/components/AMWAsideMetaLink.vue
@@ -26,6 +26,7 @@ defineProps<{
 .btn {
     padding: 8px 24px;
     text-align: center;
+    text-decoration: none;
     transition: all .5s ease-in-out;
     display: grid;
     background-color: var(--agw-btn-bg);

--- a/.vitepress/theme/components/AMWGnomeAppCard.vue
+++ b/.vitepress/theme/components/AMWGnomeAppCard.vue
@@ -1,0 +1,113 @@
+<script setup>
+import { computed } from 'vue'
+import AGWAsideMetaLink from './AMWAsideMetaLink.vue'
+import AGWAsideMetaKeyword from './AMWAsideMetaKeyword.vue'
+import { withBase, useData } from 'vitepress'
+
+const { localeIndex, theme } = useData()
+const config = theme.value.asideMeta
+import { getLinks, getKeywords } from '../composables/asidemeta'
+
+console.log(localeIndex.value)
+
+const props = defineProps({
+  app: Object
+})
+
+const cardProps = computed(() => {
+  const { icon, name, summary } = props.app.appstream
+  const repos = Object.fromEntries(
+    Object.entries(props.app.aggregation).sort((repo1, repo2) => {
+      return repo1[0] == 'sisyphus' ? -1 : 1
+    })
+  )
+  
+  const is_adaptive = props.app.appstream?.keywords?.includes('adaptive') ? ['adaptive'] : []
+  const is_donttheme = props.app.appstream?.keywords?.includes('dontthemes') ? ['dontthemes'] : []
+
+  return {
+    icon: icon,
+    name: name,
+    summary: summary,
+    links: getLinks({ ...repos, ...{ about_app: withBase(`/${localeIndex.value}/${props.app.about_app}`) }, snap: undefined }, config.links),
+    keywords: getKeywords([...is_adaptive, ...is_donttheme], config.keywords)
+  }
+})
+</script>
+
+<template>
+  <article class="AGWGnomeAppCard">
+    <div class="profile">
+      <img class="avatar-img" :src="cardProps.icon" />
+      <div class="data">
+        <h3 class="name">
+          {{ cardProps.name }}
+        </h3>
+        <div class="badges">
+          <AGWAsideMetaKeyword :keywords="cardProps.keywords" />
+        </div>
+        <p class="affiliation">
+          {{ cardProps.summary }}
+        </p>
+      </div>
+    </div>
+    <AGWAsideMetaLink :links="cardProps.links" />
+  </article>
+</template>
+
+<style scoped>
+.badges {
+  margin-top: 5px;
+  justify-content: center;
+  display: grid;
+}
+
+AGWAsideMetaLink {
+  text-decoration: none;
+}
+
+.AGWGnomeAppCard {
+  display: flex;
+  flex-direction: column;
+  border-radius: 12px;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.profile {
+  padding: 32px;
+  flex-grow: 1;
+  background-color: var(--vp-c-bg-soft);
+}
+
+.data {
+  padding-top: 20px;
+  text-align: center;
+}
+
+.avatar-img {
+  width: 64px;
+  height: 64px;
+  position: relative;
+  flex-shrink: 0;
+  margin: 0 auto;
+  border-radius: 5px;
+}
+
+.name {
+  line-height: 24px;
+  font-size: 16px;
+  margin: 0;
+  font-weight: 600;
+}
+
+.affiliation {
+  padding-top: 4px;
+  line-height: 20px;
+  font-size: 14px;
+  margin: 0;
+  font-weight: 500;
+  color: var(--vp-c-text-2);
+}
+</style>

--- a/.vitepress/theme/components/AMWGnomeAppsList.vue
+++ b/.vitepress/theme/components/AMWGnomeAppsList.vue
@@ -1,0 +1,53 @@
+<script setup>
+import { useData } from 'vitepress'
+import AGWGnomeAppCard from './AMWGnomeAppCard.vue'
+import { data as apps } from '../loaders/appsGnomeDataLoader.data.ts'
+
+const { frontmatter } = useData()
+
+const props = defineProps({
+  category: String
+})
+
+const getAppsList = () => {
+  const rawWikiApps = apps.filter((app) => {
+    return app?.frontmatter?.appstream?.keywords?.includes(props?.category)
+  })
+
+  const Apps = []
+  
+
+  rawWikiApps.forEach((app) => {
+    Apps.push({
+      ...app.frontmatter,
+      ...{ about_app: app.url }
+    })
+  })
+
+  Object.entries(frontmatter?.value?.apps?.[props.category]).forEach((app) => {
+    Apps.find((appFound) => appFound.appstream.name == app[1].appstream.name) ? '' : Apps.push({ ...app[1] })
+  })
+
+  return Apps
+}
+
+const appsByCategory = getAppsList().sort((app1, app2) => {
+  return app1.appstream.name.localeCompare(app2.appstream.name, 'ru-RU')
+})
+</script>
+
+<template>
+  <div class="container">
+    <AGWGnomeAppCard v-for="app of appsByCategory" :app="app" />
+  </div>
+</template>
+
+<style scoped>
+.container {
+  display: grid;
+  gap: 24px;
+  margin: 0 auto;
+  grid-template-columns: repeat(auto-fit, minmax(224px, 1fr));
+  max-width: calc(276px * 3 + 24px * 2);
+}
+</style>

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -7,6 +7,7 @@ import AMWHomeSponsors from './components/AMWHomeSponsors.vue'
 import AMWVideo from './components/AMWVideo.vue'
 import AMWTeamPage from './components/AMWTeamPage.vue'
 import AMWHomeTeam from './components/AMWHomeTeam.vue'
+import AGWGnomeAppsList from './components/AMWGnomeAppsList.vue'
 
 import {
   NolebaseEnhancedReadabilitiesOptions,
@@ -49,6 +50,7 @@ export default {
     app.use(NolebaseEnhancedReadabilitiesPlugin, NolebaseEnhancedReadabilitiesOptions as Options)
     app.use(NolebaseGitChangelogPlugin, { locales: NolebaseGitChangelogOptions.locales, mapAuthors: team })
     app.component('Contribution', AMWTeamPage)
+    app.component('GnomeAppsList', AGWGnomeAppsList)
 
     app.component('Video', AMWVideo)
     enhanceAppWithTabs(app)

--- a/.vitepress/theme/loaders/appsGnomeDataLoader.data.ts
+++ b/.vitepress/theme/loaders/appsGnomeDataLoader.data.ts
@@ -1,0 +1,13 @@
+import { createContentLoader } from 'vitepress'
+
+export default createContentLoader('apps/**/*.md', {
+  transform(rawData) {
+    return rawData.filter((app) => {
+      return (
+        app?.frontmatter?.appstream?.keywords?.includes('core') ||
+        app?.frontmatter?.appstream?.keywords?.includes('circle') ||
+        app?.frontmatter?.appstream?.keywords?.includes('dev')
+      )
+    })
+  }
+})

--- a/docs/en/system/apps-gnome/index.md
+++ b/docs/en/system/apps-gnome/index.md
@@ -1,0 +1,757 @@
+---
+title: Приложения для GNOME
+sidebar: false
+aside: false
+apps:
+  core:
+    'Calendar':
+      aggregation:
+        flatpak: org.gnome.Calendar
+        sisyphus: gnome-calendar
+      appstream:
+        keywords:
+          - adaptive
+        name: Calendar
+        summary: Manage your schedule
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Calendar.svg
+      about_app: https://apps.gnome.org/en/Calendar/
+    'Calculator':
+      aggregation:
+        flatpak: org.gnome.Calculator
+        sisyphus: gnome-calculator
+      appstream:
+        keywords:
+          - adaptive
+        name: Calculator
+        summary: Perform arithmetic, scientific or financial calculations
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Calculator.svg
+      about_app: https://apps.gnome.org/en/Calculator/
+    'Snapshot':
+      aggregation:
+        flatpak: org.gnome.Snapshot
+        sisyphus: snapshot
+      appstream:
+        keywords:
+          - adaptive
+        name: Camera
+        summary: Take pictures and videos
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Snapshot.svg
+      about_app: https://apps.gnome.org/en/Snapshot/
+    'Maps':
+      aggregation:
+        flatpak: org.gnome.Maps
+        sisyphus: gnome-maps
+      appstream:
+        keywords:
+          - adaptive
+        name: Maps
+        summary: Find places around the world
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Maps.svg
+      about_app: https://apps.gnome.org/en/Maps/
+    'Contacts':
+      aggregation:
+        flatpak: org.gnome.Contacts
+        sisyphus: gnome-contacts
+      appstream:
+        keywords:
+          - adaptive
+        name: Contacts
+        summary: Manage your contacts
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Contacts.svg
+      about_app: https://apps.gnome.org/en/Contacts/
+    'Settings':
+      aggregation:
+        sisyphus: gnome-control-center
+      appstream:
+        keywords:
+          - adaptive
+        name: Settings
+        summary: Utility to configure the GNOME desktop
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Settings.svg
+      about_app: https://apps.gnome.org/en/Settings/
+    'Weather':
+      aggregation:
+        flatpak: org.gnome.Weather
+        sisyphus: gnome-weather
+      appstream:
+        name: Weather
+        summary: Show weather conditions and forecast
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Weather.svg
+      about_app: https://apps.gnome.org/en/Weather/
+    'Connections':
+      aggregation:
+        flatpak: org.gnome.Connections
+        sisyphus: gnome-connections
+      appstream:
+        name: Connections
+        summary: View and use other desktops
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Connections.svg
+      about_app: https://apps.gnome.org/en/Connections/
+    'Extensions':
+      aggregation:
+        flatpak: org.gnome.Extensions
+        sisyphus: gnome-shell-extensions
+      appstream:
+        keywords:
+          - adaptive
+        name: Extensions
+        summary: Manage your GNOME Extensions
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Extensions.svg
+      about_app: https://apps.gnome.org/en/Extensions/
+    'Characters':
+      aggregation:
+        flatpak: org.gnome.Characters
+        sisyphus: gnome-characters
+      appstream:
+        keywords:
+          - adaptive
+        name: Characters
+        summary: Character map application
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Characters.svg
+      about_app: https://apps.gnome.org/en/Characters/
+    'SystemMonitor':
+      aggregation:
+        sisyphus: gnome-system-monitor
+      appstream:
+        name: System Monitor
+        summary: View and manage system resources
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.SystemMonitor.svg
+      about_app: https://apps.gnome.org/en/SystemMonitor/
+    'yelp':
+      aggregation:
+        sisyphus: yelp
+      appstream:
+        name: Help
+        summary: Help viewer for GNOME
+        icon: https://apps.gnome.org/icons/scalable/yelp.svg
+      about_app: https://apps.gnome.org/en/Yelp/
+    'TextEditor':
+      aggregation:
+        flatpak: org.gnome.TextEditor
+        sisyphus: gnome-text-editor
+      appstream:
+        name: Text Editor
+        summary: Edit text files
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.TextEditor.svg
+      about_app: https://apps.gnome.org/en/TextEditor/
+    'Nautilus':
+      aggregation:
+        sisyphus: nautilus
+      appstream:
+        keywords:
+          - adaptive
+        name: Files
+        summary: Access and organize files
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Nautilus.svg
+      about_app: https://apps.gnome.org/en/Nautilus/
+    'Software':
+      aggregation:
+        sisyphus: gnome-software
+      appstream:
+        keywords:
+          - adaptive
+        name: Software
+        summary: Install and update apps
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Software.svg
+      about_app: https://apps.gnome.org/en/Software/
+    'Clocks':
+      aggregation:
+        flatpak: org.gnome.clocks
+        sisyphus: gnome-clocks
+      appstream:
+        keywords:
+          - adaptive
+        name: Clocks
+        summary: Keep track of time
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.clocks.svg
+      about_app: https://apps.gnome.org/en/Clocks/
+    'Tour':
+      aggregation:
+        sisyphus: gnome-tour
+      appstream:
+        name: Tour
+        summary: GNOME Tour and Greeter
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Tour.svg
+      about_app: https://apps.gnome.org/en/Tour/
+  circle:
+    'Apostrophe':
+      aggregation:
+        flatpak: org.gnome.gitlab.somas.Apostrophe
+        sisyphus: apostrophe
+      appstream:
+        name: Apostrophe
+        summary: Edit Markdown in style
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.gitlab.somas.Apostrophe.svg
+      about_app: https://apps.gnome.org/en/Apostrophe/
+    'Authenticator':
+      aggregation:
+        flatpak: com.belmoussaoui.Authenticator
+        sisyphus: authenticator
+      appstream:
+        keywords:
+          - donttheme
+        name: Authenticator
+        summary: Generate Two-Factor Codes
+        icon: https://apps.gnome.org/icons/scalable/com.belmoussaoui.Authenticator.svg
+      about_app: https://apps.gnome.org/en/Authenticator/
+    'VideoTrimmer':
+      aggregation:
+        flatpak: org.gnome.gitlab.YaLTeR.VideoTrimmer
+        sisyphus: gnome-video-trimmer
+      appstream:
+        name: Video Trimmer
+        summary: Trim videos quickly
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.gitlab.YaLTeR.VideoTrimmer.svg
+      about_app: https://apps.gnome.org/en/VideoTrimmer/
+    'WebfontKitGenerator':
+      aggregation:
+        flatpak: com.rafaelmardojai.WebfontKitGenerator
+        sisyphus: webfont-kit-generator
+      appstream:
+        keywords:
+          - donttheme
+        name: Webfont Kit Generator
+        summary: Create @font-face kits easily
+        icon: https://apps.gnome.org/icons/scalable/com.rafaelmardojai.WebfontKitGenerator.svg
+      about_app: https://apps.gnome.org/en/WebfontKitGenerator/
+    'Decoder':
+      aggregation:
+        flatpak: com.belmoussaoui.Decoder
+        sisyphus: gnome-qr-decoder
+      appstream:
+        keywords:
+          - donttheme
+          - adaptive
+        name: Decoder
+        summary: Scan and Generate QR Codes
+        icon: https://apps.gnome.org/icons/scalable/com.belmoussaoui.Decoder.svg
+      about_app: https://apps.gnome.org/en/Decoder/
+    'Decibels':
+      aggregation:
+        flatpak: org.gnome.Decibels
+        sisyphus: decibels
+      appstream:
+        keywords:
+          - adaptive
+        name: Decibels
+        summary: Play audio files
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Decibels.svg
+      about_app: https://apps.gnome.org/en/Decibels/
+    'Health':
+      aggregation:
+        flatpak: dev.Cogitri.Health
+        sisyphus: gnome-health
+      appstream:
+        name: Health
+        summary: Track your fitness goals
+        icon: https://apps.gnome.org/icons/scalable/dev.Cogitri.Health.svg
+      about_app: https://apps.gnome.org/en/Health/
+    'Identity':
+      aggregation:
+        flatpak: org.gnome.gitlab.YaLTeR.Identity
+        sisyphus: identity
+      appstream:
+        name: Identity
+        summary: Compare images and videos
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.gitlab.YaLTeR.Identity.svg
+      about_app: https://apps.gnome.org/en/Identity/
+    'MetadataCleaner':
+      aggregation:
+        flatpak: fr.romainvigier.MetadataCleaner
+      appstream:
+        keywords:
+          - adaptive
+        name: Metadata Cleaner
+        summary: View and clean metadata in files
+        icon: https://apps.gnome.org/icons/scalable/fr.romainvigier.MetadataCleaner.svg
+      about_app: https://apps.gnome.org/en/MetadataCleaner/
+    'SharePreview':
+      aggregation:
+        flatpak: com.rafaelmardojai.SharePreview
+        sisyphus: share-preview
+      appstream:
+        keywords:
+          - donttheme
+        name: Share Preview
+        summary: Test social media cards locally
+        icon: https://apps.gnome.org/icons/scalable/com.rafaelmardojai.SharePreview.svg
+      about_app: https://apps.gnome.org/en/SharePreview/
+    'Podcasts':
+      aggregation:
+        flatpak: org.gnome.Podcasts
+      appstream:
+        keywords:
+          - donttheme
+          - adaptive
+        name: Podcasts
+        summary: Listen to your favorite shows
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Podcasts.svg
+      about_app: https://apps.gnome.org/en/Podcasts/
+    'Clairvoyant':
+      aggregation:
+        flatpak: com.github.cassidyjames.clairvoyant
+      appstream:
+        name: Провидец
+        summary: Задавайте вопросы, получайте предсказания
+        icon: https://apps.gnome.org/icons/scalable/com.github.cassidyjames.clairvoyant.svg
+      about_app: https://apps.gnome.org/en/Clairvoyant/
+    'DejaDup':
+      aggregation:
+        flatpak: org.gnome.DejaDup
+        sisyphus: deja-dup
+      appstream:
+        keywords:
+          - adaptive
+        name: Резервные копии Déjà Dup
+        summary: Защитите себя от потери данных
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.DejaDup.svg
+      about_app: https://apps.gnome.org/en/DejaDup/
+    'Raider':
+      aggregation:
+        flatpak: com.github.ADBeveridge.Raider
+      appstream:
+        keywords:
+          - adaptive
+        name: Файловый шредер
+        summary: Безвозвратно удалите ваши файлы
+        icon: https://apps.gnome.org/icons/scalable/com.github.ADBeveridge.Raider.svg
+      about_app: https://apps.gnome.org/en/Raider/
+    'Citations':
+      aggregation:
+        flatpak: org.gnome.World.Citations
+      appstream:
+        keywords:
+          - donttheme
+          - adaptive
+        name: Цитаты
+        summary: Управляйте своей библиографией
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.World.Citations.svg
+      about_app: https://apps.gnome.org/en/Citations/
+    'Chessclock':
+      aggregation:
+        flatpak: com.clarahobbs.chessclock
+      appstream:
+        name: Шахматные часы
+        summary: Партии в шахматы на время
+        icon: https://apps.gnome.org/icons/scalable/com.clarahobbs.chessclock.svg
+      about_app: https://apps.gnome.org/en/Chessclock/
+    'Emblem':
+      aggregation:
+        flatpak: org.gnome.design.Emblem
+        sisyphus: emblem
+      appstream:
+        name: Эмблема
+        summary: Создание аватаров проекта
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.design.Emblem.svg
+      about_app: https://apps.gnome.org/en/Emblem/
+    'AudioSharing':
+      aggregation:
+        flatpak: de.haeckerfelix.AudioSharing
+        sisyphus: audiosharing
+      appstream:
+        keywords:
+          - adaptive
+        name: Audio Sharing
+        summary: Делитесь аудио с вашего компьютера
+        icon: https://apps.gnome.org/icons/scalable/de.haeckerfelix.AudioSharing.svg
+      about_app: https://apps.gnome.org/en/AudioSharing/
+    'Biblioteca':
+      aggregation:
+        flatpak: app.drey.Biblioteca
+      appstream:
+        keywords:
+          - adaptive
+        name: Biblioteca
+        summary: Читайте документацию GNOME в автономном режиме
+        icon: https://apps.gnome.org/icons/scalable/app.drey.Biblioteca.svg
+      about_app: https://apps.gnome.org/en/Biblioteca/
+    'Blanket':
+      aggregation:
+        flatpak: com.rafaelmardojai.Blanket
+        sisyphus: blanket
+      appstream:
+        keywords:
+          - donttheme
+        name: Blanket
+        summary: Слушайте звуки окружающей среды
+        icon: https://apps.gnome.org/icons/scalable/com.rafaelmardojai.Blanket.svg
+      about_app: https://apps.gnome.org/en/Blanket/
+    'Boatswain':
+      aggregation:
+        flatpak: com.feaneron.Boatswain
+      appstream:
+        name: Boatswain
+        summary: Управляйте своими Elgato Stream Decks
+        icon: https://apps.gnome.org/icons/scalable/com.feaneron.Boatswain.svg
+      about_app: https://apps.gnome.org/en/Boatswain/
+    'Collision':
+      aggregation:
+        flatpak: dev.geopjr.Collision
+      appstream:
+        keywords:
+          - adaptive
+        name: Collision
+        summary: Проверьте хеши ваших файлов
+        icon: https://apps.gnome.org/icons/scalable/dev.geopjr.Collision.svg
+      about_app: https://apps.gnome.org/en/Collision/
+    'Commit':
+      aggregation:
+        flatpak: re.sonny.Commit
+      appstream:
+        name: Commit
+        summary: Редактор сообщений коммитов
+        icon: https://apps.gnome.org/icons/scalable/re.sonny.Commit.svg
+      about_app: https://apps.gnome.org/en/Commit/
+    'Curtail':
+      aggregation:
+        flatpak: com.github.huluti.Curtail
+        sisyphus: curtail
+      appstream:
+        name: Curtail
+        summary: Сжатие изображений
+        icon: https://apps.gnome.org/icons/scalable/com.github.huluti.Curtail.svg
+      about_app: https://apps.gnome.org/en/Curtail/
+    'EarTag':
+      aggregation:
+        flatpak: app.drey.EarTag
+        sisyphus: eartag
+      appstream:
+        keywords:
+          - adaptive
+        name: Ear Tag
+        summary: Редактор тегов аудиофайлов
+        icon: https://apps.gnome.org/icons/scalable/app.drey.EarTag.svg
+      about_app: https://apps.gnome.org/en/EarTag/
+    'Elastic':
+      aggregation:
+        flatpak: app.drey.Elastic
+      appstream:
+        keywords:
+          - adaptive
+        name: Elastic
+        summary: Проектирование пружинных анимаций
+        icon: https://apps.gnome.org/icons/scalable/app.drey.Elastic.svg
+      about_app: https://apps.gnome.org/en/Elastic/
+    'Eyedropper':
+      aggregation:
+        flatpak: com.github.finefindus.eyedropper
+        sisyphus: eyedropper
+      appstream:
+        name: Eyedropper
+        summary: Выбирайте и форматируйте цвета
+        icon: https://apps.gnome.org/icons/scalable/com.github.finefindus.eyedropper.svg
+      about_app: https://apps.gnome.org/en/Eyedropper/
+    'ForgeSparks':
+      aggregation:
+        flatpak: com.mardojai.ForgeSparks
+      appstream:
+        keywords:
+          - adaptive
+        name: Forge Sparks
+        summary: Получайте уведомления Git forges
+        icon: https://apps.gnome.org/icons/scalable/com.mardojai.ForgeSparks.svg
+      about_app: https://apps.gnome.org/en/ForgeSparks/
+    'Graphs':
+      aggregation:
+        flatpak: se.sjoerd.Graphs
+        sisyphus: graphs
+      appstream:
+        keywords:
+          - donttheme
+          - adaptive
+        name: Graphs
+        summary: Построение графиков и манипулирование данными
+        icon: https://apps.gnome.org/icons/scalable/se.sjoerd.Graphs.svg
+      about_app: https://apps.gnome.org/en/Graphs/
+    'Hieroglyphic':
+      aggregation:
+        flatpak: io.github.finefindus.Hieroglyphic
+      appstream:
+        name: Hieroglyphic
+        summary: Поиск символов LaTeX
+        icon: https://apps.gnome.org/icons/scalable/io.github.finefindus.Hieroglyphic.svg
+      about_app: https://apps.gnome.org/en/Hieroglyphic/
+    'Impression':
+      aggregation:
+        flatpak: io.gitlab.adhami3310.Impression
+        sisyphus: impression
+      appstream:
+        keywords:
+          - adaptive
+        name: Impression
+        summary: Создание загрузочных дисков
+        icon: https://apps.gnome.org/icons/scalable/io.gitlab.adhami3310.Impression.svg
+      about_app: https://apps.gnome.org/en/Impression/
+    'Junction':
+      aggregation:
+        flatpak: re.sonny.Junction
+        sisyphus: junction
+      appstream:
+        keywords:
+          - adaptive
+        name: Junction
+        summary: Выбор приложения
+        icon: https://apps.gnome.org/icons/scalable/re.sonny.Junction.svg
+      about_app: https://apps.gnome.org/en/Junction/
+    'Khronos':
+      aggregation:
+        flatpak: io.github.lainsce.Khronos
+        sisyphus: khronos
+      appstream:
+        keywords:
+          - donttheme
+        name: Khronos
+        summary: Записывайте в журнал время, затраченное на выполнение заданий
+        icon: https://apps.gnome.org/icons/scalable/io.github.lainsce.Khronos.svg
+      about_app: https://apps.gnome.org/en/Khronos/
+    'Komikku':
+      aggregation:
+        flatpak: info.febvre.Komikku
+      appstream:
+        keywords:
+          - adaptive
+        name: Komikku
+        summary: Откройте для себя и читайте мангу и комиксы
+        icon: https://apps.gnome.org/icons/scalable/info.febvre.Komikku.svg
+      about_app: https://apps.gnome.org/en/Komikku/
+    'Letterpress':
+      aggregation:
+        flatpak: io.gitlab.gregorni.Letterpress
+        sisyphus: letterpress
+      appstream:
+        keywords:
+          - adaptive
+        name: Letterpress
+        summary: Создайте красивые ASCII-арты
+        icon: https://apps.gnome.org/icons/scalable/io.gitlab.gregorni.Letterpress.svg
+      about_app: https://apps.gnome.org/en/Letterpress/
+    'Lorem':
+      aggregation:
+        flatpak: org.gnome.design.Lorem
+      appstream:
+        keywords:
+          - donttheme
+          - adaptive
+        name: Lorem
+        summary: Создание текста-заполнителя
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.design.Lorem.svg
+      about_app: https://apps.gnome.org/en/Lorem/
+    'Mousai':
+      aggregation:
+        flatpak: io.github.seadve.Mousai
+        sisyphus: mousai
+      appstream:
+        keywords:
+          - adaptive
+        name: Mousai
+        summary: Распознавайте песни за секунды
+        icon: https://apps.gnome.org/icons/scalable/io.github.seadve.Mousai.svg
+      about_app: https://apps.gnome.org/en/Mousai/
+    'NewsFlash':
+      aggregation:
+        flatpak: io.gitlab.news_flash.NewsFlash
+        sisyphus: newsflash
+      appstream:
+        keywords:
+          - donttheme
+          - adaptive
+        name: NewsFlash
+        summary: Следите за своими каналами
+        icon: https://apps.gnome.org/icons/scalable/io.gitlab.news_flash.NewsFlash.svg
+      about_app: https://apps.gnome.org/en/NewsFlash/
+    'Obfuscate':
+      aggregation:
+        flatpak: com.belmoussaoui.Obfuscate
+        sisyphus: obfuscate
+      appstream:
+        keywords:
+          - donttheme
+          - adaptive
+        name: Obfuscate
+        summary: Цензор личной информации
+        icon: https://apps.gnome.org/icons/scalable/com.belmoussaoui.Obfuscate.svg
+      about_app: https://apps.gnome.org/en/Obfuscate/
+    'PdfMetadataEditor':
+      aggregation:
+        flatpak: io.github.diegoivan.pdf_metadata_editor
+      appstream:
+        keywords:
+          - adaptive
+        name: Paper Clip
+        summary: Редактирование метаданных документов PDF
+        icon: https://apps.gnome.org/icons/scalable/io.github.diegoivan.pdf_metadata_editor.svg
+      about_app: https://apps.gnome.org/en/PdfMetadataEditor/
+    'PikaBackup':
+      aggregation:
+        flatpak: org.gnome.World.PikaBackup
+        sisyphus: pika-backup
+      appstream:
+        keywords:
+          - donttheme
+          - adaptive
+        name: Pika Backup
+        summary: Обеспечьте сохранность своих данных
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.World.PikaBackup.svg
+      about_app: https://apps.gnome.org/en/PikaBackup/
+    'Polari':
+      aggregation:
+        flatpak: org.gnome.Polari
+        sisyphus: polari
+      appstream:
+        keywords:
+          - adaptive
+        name: Polari
+        summary: Разговор с людьми в IRC
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Polari.svg
+      about_app: https://apps.gnome.org/en/Polari/
+    'DieBahn':
+      aggregation:
+        flatpak: de.schmidhuberj.DieBahn
+      appstream:
+        keywords:
+          - adaptive
+        name: Railway
+        summary: Найти всю информацию о путешествиях
+        icon: https://apps.gnome.org/icons/scalable/de.schmidhuberj.DieBahn.svg
+      about_app: https://apps.gnome.org/en/DieBahn/
+    'Secrets':
+      aggregation:
+        flatpak: org.gnome.World.Secrets
+        sisyphus: secrets
+      appstream:
+        keywords:
+          - donttheme
+          - adaptive
+        name: Secrets
+        summary: Управление паролями
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.World.Secrets.svg
+      about_app: https://apps.gnome.org/en/Secrets/
+    'Shortwave':
+      aggregation:
+        flatpak: de.haeckerfelix.Shortwave
+        sisyphus: shortwave
+      appstream:
+        keywords:
+          - donttheme
+        name: Shortwave
+        summary: Слушайте интернет-радио
+        icon: https://apps.gnome.org/icons/scalable/de.haeckerfelix.Shortwave.svg
+      about_app: https://apps.gnome.org/en/Shortwave/
+    'Solanum':
+      aggregation:
+        flatpak: org.gnome.Solanum
+        sisyphus: solanum
+      appstream:
+        name: Solanum
+        summary: Баланс рабочего времени и времени перерыва
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Solanum.svg
+      about_app: https://apps.gnome.org/en/Solanum/
+    'Tangram':
+      aggregation:
+        flatpak: re.sonny.Tangram
+        sisyphus: tangram
+      appstream:
+        keywords:
+          - adaptive
+        name: Tangram
+        summary: Браузер для закреплённых вкладок
+        icon: https://apps.gnome.org/icons/scalable/re.sonny.Tangram.svg
+      about_app: https://apps.gnome.org/en/Tangram/
+    'TextPieces':
+      aggregation:
+        flatpak: io.gitlab.liferooter.TextPieces
+        sisyphus: textpieces
+      appstream:
+        keywords:
+          - adaptive
+        name: Text Pieces
+        summary: Блокнот разработчика
+        icon: https://apps.gnome.org/icons/scalable/io.gitlab.liferooter.TextPieces.svg
+      about_app: https://apps.gnome.org/en/TextPieces/
+    'Warp':
+      aggregation:
+        flatpak: app.drey.Warp
+        sisyphus: warp
+      appstream:
+        keywords:
+          - adaptive
+        name: Warp
+        summary: Быстрая и безопасная передача файлов
+        icon: https://apps.gnome.org/icons/scalable/app.drey.Warp.svg
+      about_app: https://apps.gnome.org/en/Warp/
+    'Workbench':
+      aggregation:
+        flatpak: re.sonny.Workbench
+      appstream:
+        name: Workbench
+        summary: Прототип с использованием технологий GNOME
+        icon: https://apps.gnome.org/icons/scalable/re.sonny.Workbench.svg
+      about_app: https://apps.gnome.org/en/Workbench/
+  dev:
+    'DconfEditor':
+      aggregation:
+        flatpak: ca.desrt.dconf-editor
+        sisyphus: dconf-editor
+      appstream:
+        name: Редактор Dconf
+        summary: Графический инструмент для редактирования базы данных dconf
+        icon: https://apps.gnome.org/icons/scalable/ca.desrt.dconf-editor.svg
+      about_app: https://apps.gnome.org/en/DconfEditor/
+    'Builder':
+      aggregation:
+        flatpak: org.gnome.Builder
+        sisyphus: gnome-builder
+      appstream:
+        name: Builder
+        summary: IDE для GNOME
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Builder.svg
+      about_app: https://apps.gnome.org/en/Builder/
+    'Dspy':
+      aggregation:
+        flatpak: org.gnome.dspy
+        sisyphus: dspy
+      appstream:
+        name: D-Spy
+        summary: Анализ соединений D-Bus
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.dspy.svg
+      about_app: https://apps.gnome.org/en/Dspy/
+    'Devhelp':
+      aggregation:
+        flatpak: org.gnome.Devhelp
+        sisyphus: devhelp
+      appstream:
+        name: Devhelp
+        summary: Инструмент разработчика для поиска и просмотра документации к API
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Devhelp.svg
+      about_app: https://apps.gnome.org/en/Devhelp/
+    'Sysprof':
+      aggregation:
+        sisyphus: sysprof
+      appstream:
+        name: Sysprof
+        summary: Профилирование приложения или всей системы
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Sysprof.svg
+      about_app: https://apps.gnome.org/en/Sysprof/
+---
+
+# Applications for GNOME
+
+All of the applications in this review are designed with the GNOME philosophy in mind. They are easy to understand and use, with a consistent and polished design and a noticeable attention to detail. Naturally, they are free software and are committed to being part of a welcoming and friendly community. These applications will fit perfectly into your GNOME desktop.
+
+## Core applications
+
+GNOME Core applications are designed to perform common tasks on the GNOME desktop. They are usually pre-installed on your ALT Regular Gnome system.
+
+<GnomeAppsList category="core"/>
+
+## Circle applications
+
+GNOME Circle contains applications that extend the GNOME ecosystem. It epitomizes the excellent add-on software available for the GNOME platform
+
+<GnomeAppsList category="circle"/>
+
+## Development Tools
+
+The development tools in the GNOME environment help you develop and design new applications and make it easy to contribute to existing applications.
+
+<GnomeAppsList category="dev"/>

--- a/docs/system/apps-gnome/index.md
+++ b/docs/system/apps-gnome/index.md
@@ -1,0 +1,757 @@
+---
+title: Приложения для GNOME
+sidebar: false
+aside: false
+apps:
+  core:
+    'Calendar':
+      aggregation:
+        flatpak: org.gnome.Calendar
+        sisyphus: gnome-calendar
+      appstream:
+        keywords:
+          - adaptive
+        name: Календарь
+        summary: Управление расписанием
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Calendar.svg
+      about_app: https://apps.gnome.org/ru/Calendar/
+    'Calculator':
+      aggregation:
+        flatpak: org.gnome.Calculator
+        sisyphus: gnome-calculator
+      appstream:
+        keywords:
+          - adaptive
+        name: Калькулятор
+        summary: 'Вычисления: арифметические, научные и финансовые'
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Calculator.svg
+      about_app: https://apps.gnome.org/ru/Calculator/
+    'Snapshot':
+      aggregation:
+        flatpak: org.gnome.Snapshot
+        sisyphus: snapshot
+      appstream:
+        keywords:
+          - adaptive
+        name: Камера
+        summary: Снимайте фото и видео
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Snapshot.svg
+      about_app: https://apps.gnome.org/ru/Snapshot/
+    'Maps':
+      aggregation:
+        flatpak: org.gnome.Maps
+        sisyphus: gnome-maps
+      appstream:
+        keywords:
+          - adaptive
+        name: Карты
+        summary: Поиск местоположений по всему миру
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Maps.svg
+      about_app: https://apps.gnome.org/ru/Maps/
+    'Contacts':
+      aggregation:
+        flatpak: org.gnome.Contacts
+        sisyphus: gnome-contacts
+      appstream:
+        keywords:
+          - adaptive
+        name: Контакты
+        summary: Управление контактами
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Contacts.svg
+      about_app: https://apps.gnome.org/ru/Contacts/
+    'Settings':
+      aggregation:
+        sisyphus: gnome-control-center
+      appstream:
+        keywords:
+          - adaptive
+        name: Настройки
+        summary: Инструмент для настройки рабочего стола GNOME
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Settings.svg
+      about_app: https://apps.gnome.org/ru/Settings/
+    'Weather':
+      aggregation:
+        flatpak: org.gnome.Weather
+        sisyphus: gnome-weather
+      appstream:
+        name: Погода
+        summary: Просмотр погодных условий и прогноза
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Weather.svg
+      about_app: https://apps.gnome.org/ru/Weather/
+    'Connections':
+      aggregation:
+        flatpak: org.gnome.Connections
+        sisyphus: gnome-connections
+      appstream:
+        name: Подключения
+        summary: Просмотр и использование других рабочих столов
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Connections.svg
+      about_app: https://apps.gnome.org/ru/Connections/
+    'Extensions':
+      aggregation:
+        flatpak: org.gnome.Extensions
+        sisyphus: gnome-shell-extensions
+      appstream:
+        keywords:
+          - adaptive
+        name: Расширения
+        summary: Управление расширениями GNOME Shell
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Extensions.svg
+      about_app: https://apps.gnome.org/ru/Extensions/
+    'Characters':
+      aggregation:
+        flatpak: org.gnome.Characters
+        sisyphus: gnome-characters
+      appstream:
+        keywords:
+          - adaptive
+        name: Символы
+        summary: Приложение карты символов
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Characters.svg
+      about_app: https://apps.gnome.org/ru/Characters/
+    'SystemMonitor':
+      aggregation:
+        sisyphus: gnome-system-monitor
+      appstream:
+        name: Системный монитор
+        summary: Просмотр и управление ресурсами системы
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.SystemMonitor.svg
+      about_app: https://apps.gnome.org/ru/SystemMonitor/
+    'Yelp':
+      aggregation:
+        sisyphus: yelp
+      appstream:
+        name: Справка
+        summary: Приложение для просмотра справки GNOME
+        icon: https://apps.gnome.org/icons/scalable/yelp.svg
+      about_app: https://apps.gnome.org/ru/Yelp/
+    'TextEditor':
+      aggregation:
+        flatpak: org.gnome.TextEditor
+        sisyphus: gnome-text-editor
+      appstream:
+        name: Текстовый редактор
+        summary: Редактирование текстовых файлов
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.TextEditor.svg
+      about_app: https://apps.gnome.org/ru/TextEditor/
+    'Nautilus':
+      aggregation:
+        sisyphus: nautilus
+      appstream:
+        keywords:
+          - adaptive
+        name: Файлы
+        summary: Управление файлами
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Nautilus.svg
+      about_app: https://apps.gnome.org/ru/Nautilus/
+    'Software':
+      aggregation:
+        sisyphus: gnome-software
+      appstream:
+        keywords:
+          - adaptive
+        name: Центр приложений
+        summary: Установка и обновление приложений
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Software.svg
+      about_app: https://apps.gnome.org/ru/Software/
+    'Clocks':
+      aggregation:
+        flatpak: org.gnome.clocks
+        sisyphus: gnome-clocks
+      appstream:
+        keywords:
+          - adaptive
+        name: Часы
+        summary: Следить за временем
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.clocks.svg
+      about_app: https://apps.gnome.org/ru/Clocks/
+    'Tour':
+      aggregation:
+        sisyphus: gnome-tour
+      appstream:
+        name: Экскурсия
+        summary: Экскурсия и Приветствие GNOME
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Tour.svg
+      about_app: https://apps.gnome.org/ru/Tour/
+  circle:
+    'Apostrophe':
+      aggregation:
+        flatpak: org.gnome.gitlab.somas.Apostrophe
+        sisyphus: apostrophe
+      appstream:
+        name: Апостроф
+        summary: Редактировать в стиле Markdown
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.gitlab.somas.Apostrophe.svg
+      about_app: https://apps.gnome.org/ru/Apostrophe/
+    'Authenticator':
+      aggregation:
+        flatpak: com.belmoussaoui.Authenticator
+        sisyphus: authenticator
+      appstream:
+        keywords:
+          - donttheme
+        name: Аутентификатор
+        summary: Создание двухфакторных кодов
+        icon: https://apps.gnome.org/icons/scalable/com.belmoussaoui.Authenticator.svg
+      about_app: https://apps.gnome.org/ru/Authenticator/
+    'VideoTrimmer':
+      aggregation:
+        flatpak: org.gnome.gitlab.YaLTeR.VideoTrimmer
+        sisyphus: gnome-video-trimmer
+      appstream:
+        name: Видеотриммер
+        summary: Быстрая обрезка видео-файлов
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.gitlab.YaLTeR.VideoTrimmer.svg
+      about_app: https://apps.gnome.org/ru/VideoTrimmer/
+    'WebfontKitGenerator':
+      aggregation:
+        flatpak: com.rafaelmardojai.WebfontKitGenerator
+        sisyphus: webfont-kit-generator
+      appstream:
+        keywords:
+          - donttheme
+        name: Генератор набора веб-шрифтов
+        summary: Легко создавайте наборы @font-face
+        icon: https://apps.gnome.org/icons/scalable/com.rafaelmardojai.WebfontKitGenerator.svg
+      about_app: https://apps.gnome.org/ru/WebfontKitGenerator/
+    'Decoder':
+      aggregation:
+        flatpak: com.belmoussaoui.Decoder
+        sisyphus: gnome-qr-decoder
+      appstream:
+        keywords:
+          - donttheme
+          - adaptive
+        name: Декодер
+        summary: Сканирование и генерация QR-кодов
+        icon: https://apps.gnome.org/icons/scalable/com.belmoussaoui.Decoder.svg
+      about_app: https://apps.gnome.org/ru/Decoder/
+    'Decibels':
+      aggregation:
+        flatpak: org.gnome.Decibels
+        sisyphus: decibels
+      appstream:
+        keywords:
+          - adaptive
+        name: Децибелы
+        summary: Воспроизведение аудио файлов
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Decibels.svg
+      about_app: https://apps.gnome.org/ru/Decibels/
+    'Health':
+      aggregation:
+        flatpak: dev.Cogitri.Health
+        sisyphus: gnome-health
+      appstream:
+        name: Здоровье
+        summary: Отслеживайте свои фитнес-цели
+        icon: https://apps.gnome.org/icons/scalable/dev.Cogitri.Health.svg
+      about_app: https://apps.gnome.org/ru/Health/
+    'Identity':
+      aggregation:
+        flatpak: org.gnome.gitlab.YaLTeR.Identity
+        sisyphus: identity
+      appstream:
+        name: Идентичность
+        summary: Сравнение изображений и видео
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.gitlab.YaLTeR.Identity.svg
+      about_app: https://apps.gnome.org/ru/Identity/
+    'MetadataCleaner':
+      aggregation:
+        flatpak: fr.romainvigier.MetadataCleaner
+      appstream:
+        keywords:
+          - adaptive
+        name: Очиститель метаданных
+        summary: Просмотр и очистка метаданных в файлах
+        icon: https://apps.gnome.org/icons/scalable/fr.romainvigier.MetadataCleaner.svg
+      about_app: https://apps.gnome.org/ru/MetadataCleaner/
+    'SharePreview':
+      aggregation:
+        flatpak: com.rafaelmardojai.SharePreview
+        sisyphus: share-preview
+      appstream:
+        keywords:
+          - donttheme
+        name: Поделиться превью
+        summary: Тестируйте карточки социальных сетей на местах
+        icon: https://apps.gnome.org/icons/scalable/com.rafaelmardojai.SharePreview.svg
+      about_app: https://apps.gnome.org/ru/SharePreview/
+    'Podcasts':
+      aggregation:
+        flatpak: org.gnome.Podcasts
+      appstream:
+        keywords:
+          - donttheme
+          - adaptive
+        name: Подкасты
+        summary: Слушайте свои любимые шоу
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Podcasts.svg
+      about_app: https://apps.gnome.org/ru/Podcasts/
+    'Clairvoyant':
+      aggregation:
+        flatpak: com.github.cassidyjames.clairvoyant
+      appstream:
+        name: Провидец
+        summary: Задавайте вопросы, получайте предсказания
+        icon: https://apps.gnome.org/icons/scalable/com.github.cassidyjames.clairvoyant.svg
+      about_app: https://apps.gnome.org/ru/Clairvoyant/
+    'DejaDup':
+      aggregation:
+        flatpak: org.gnome.DejaDup
+        sisyphus: deja-dup
+      appstream:
+        keywords:
+          - adaptive
+        name: Резервные копии Déjà Dup
+        summary: Защитите себя от потери данных
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.DejaDup.svg
+      about_app: https://apps.gnome.org/ru/DejaDup/
+    'Raider':
+      aggregation:
+        flatpak: com.github.ADBeveridge.Raider
+      appstream:
+        keywords:
+          - adaptive
+        name: Файловый шредер
+        summary: Безвозвратно удалите ваши файлы
+        icon: https://apps.gnome.org/icons/scalable/com.github.ADBeveridge.Raider.svg
+      about_app: https://apps.gnome.org/ru/Raider/
+    'Citations':
+      aggregation:
+        flatpak: org.gnome.World.Citations
+      appstream:
+        keywords:
+          - donttheme
+          - adaptive
+        name: Цитаты
+        summary: Управляйте своей библиографией
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.World.Citations.svg
+      about_app: https://apps.gnome.org/ru/Citations/
+    'Chessclock':
+      aggregation:
+        flatpak: com.clarahobbs.chessclock
+      appstream:
+        name: Шахматные часы
+        summary: Партии в шахматы на время
+        icon: https://apps.gnome.org/icons/scalable/com.clarahobbs.chessclock.svg
+      about_app: https://apps.gnome.org/ru/Chessclock/
+    'Emblem':
+      aggregation:
+        flatpak: org.gnome.design.Emblem
+        sisyphus: emblem
+      appstream:
+        name: Эмблема
+        summary: Создание аватаров проекта
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.design.Emblem.svg
+      about_app: https://apps.gnome.org/ru/Emblem/
+    'AudioSharing':
+      aggregation:
+        flatpak: de.haeckerfelix.AudioSharing
+        sisyphus: audiosharing
+      appstream:
+        keywords:
+          - adaptive
+        name: Audio Sharing
+        summary: Делитесь аудио с вашего компьютера
+        icon: https://apps.gnome.org/icons/scalable/de.haeckerfelix.AudioSharing.svg
+      about_app: https://apps.gnome.org/ru/AudioSharing/
+    'Biblioteca':
+      aggregation:
+        flatpak: app.drey.Biblioteca
+      appstream:
+        keywords:
+          - adaptive
+        name: Biblioteca
+        summary: Читайте документацию GNOME в автономном режиме
+        icon: https://apps.gnome.org/icons/scalable/app.drey.Biblioteca.svg
+      about_app: https://apps.gnome.org/ru/Biblioteca/
+    'Blanket':
+      aggregation:
+        flatpak: com.rafaelmardojai.Blanket
+        sisyphus: blanket
+      appstream:
+        keywords:
+          - donttheme
+        name: Blanket
+        summary: Слушайте звуки окружающей среды
+        icon: https://apps.gnome.org/icons/scalable/com.rafaelmardojai.Blanket.svg
+      about_app: https://apps.gnome.org/ru/Blanket/
+    'Boatswain':
+      aggregation:
+        flatpak: com.feaneron.Boatswain
+      appstream:
+        name: Boatswain
+        summary: Управляйте своими Elgato Stream Decks
+        icon: https://apps.gnome.org/icons/scalable/com.feaneron.Boatswain.svg
+      about_app: https://apps.gnome.org/ru/Boatswain/
+    'Collision':
+      aggregation:
+        flatpak: dev.geopjr.Collision
+      appstream:
+        keywords:
+          - adaptive
+        name: Collision
+        summary: Проверьте хеши ваших файлов
+        icon: https://apps.gnome.org/icons/scalable/dev.geopjr.Collision.svg
+      about_app: https://apps.gnome.org/ru/Collision/
+    'Commit':
+      aggregation:
+        flatpak: re.sonny.Commit
+      appstream:
+        name: Commit
+        summary: Редактор сообщений коммитов
+        icon: https://apps.gnome.org/icons/scalable/re.sonny.Commit.svg
+      about_app: https://apps.gnome.org/ru/Commit/
+    'Curtail':
+      aggregation:
+        flatpak: com.github.huluti.Curtail
+        sisyphus: curtail
+      appstream:
+        name: Curtail
+        summary: Сжатие изображений
+        icon: https://apps.gnome.org/icons/scalable/com.github.huluti.Curtail.svg
+      about_app: https://apps.gnome.org/ru/Curtail/
+    'EarTag':
+      aggregation:
+        flatpak: app.drey.EarTag
+        sisyphus: eartag
+      appstream:
+        keywords:
+          - adaptive
+        name: Ear Tag
+        summary: Редактор тегов аудиофайлов
+        icon: https://apps.gnome.org/icons/scalable/app.drey.EarTag.svg
+      about_app: https://apps.gnome.org/ru/EarTag/
+    'Elastic':
+      aggregation:
+        flatpak: app.drey.Elastic
+      appstream:
+        keywords:
+          - adaptive
+        name: Elastic
+        summary: Проектирование пружинных анимаций
+        icon: https://apps.gnome.org/icons/scalable/app.drey.Elastic.svg
+      about_app: https://apps.gnome.org/ru/Elastic/
+    'Eyedropper':
+      aggregation:
+        flatpak: com.github.finefindus.eyedropper
+        sisyphus: eyedropper
+      appstream:
+        name: Eyedropper
+        summary: Выбирайте и форматируйте цвета
+        icon: https://apps.gnome.org/icons/scalable/com.github.finefindus.eyedropper.svg
+      about_app: https://apps.gnome.org/ru/Eyedropper/
+    'ForgeSparks':
+      aggregation:
+        flatpak: com.mardojai.ForgeSparks
+      appstream:
+        keywords:
+          - adaptive
+        name: Forge Sparks
+        summary: Получайте уведомления Git forges
+        icon: https://apps.gnome.org/icons/scalable/com.mardojai.ForgeSparks.svg
+      about_app: https://apps.gnome.org/ru/ForgeSparks/
+    'Graphs':
+      aggregation:
+        flatpak: se.sjoerd.Graphs
+        sisyphus: graphs
+      appstream:
+        keywords:
+          - donttheme
+          - adaptive
+        name: Graphs
+        summary: Построение графиков и манипулирование данными
+        icon: https://apps.gnome.org/icons/scalable/se.sjoerd.Graphs.svg
+      about_app: https://apps.gnome.org/ru/Graphs/
+    'Hieroglyphic':
+      aggregation:
+        flatpak: io.github.finefindus.Hieroglyphic
+      appstream:
+        name: Hieroglyphic
+        summary: Поиск символов LaTeX
+        icon: https://apps.gnome.org/icons/scalable/io.github.finefindus.Hieroglyphic.svg
+      about_app: https://apps.gnome.org/ru/Hieroglyphic/
+    'Impression':
+      aggregation:
+        flatpak: io.gitlab.adhami3310.Impression
+        sisyphus: impression
+      appstream:
+        keywords:
+          - adaptive
+        name: Impression
+        summary: Создание загрузочных дисков
+        icon: https://apps.gnome.org/icons/scalable/io.gitlab.adhami3310.Impression.svg
+      about_app: https://apps.gnome.org/ru/Impression/
+    'Junction':
+      aggregation:
+        flatpak: re.sonny.Junction
+        sisyphus: junction
+      appstream:
+        keywords:
+          - adaptive
+        name: Junction
+        summary: Выбор приложения
+        icon: https://apps.gnome.org/icons/scalable/re.sonny.Junction.svg
+      about_app: https://apps.gnome.org/ru/Junction/
+    'Khronos':
+      aggregation:
+        flatpak: io.github.lainsce.Khronos
+        sisyphus: khronos
+      appstream:
+        keywords:
+          - donttheme
+        name: Khronos
+        summary: Записывайте в журнал время, затраченное на выполнение заданий
+        icon: https://apps.gnome.org/icons/scalable/io.github.lainsce.Khronos.svg
+      about_app: https://apps.gnome.org/ru/Khronos/
+    'Komikku':
+      aggregation:
+        flatpak: info.febvre.Komikku
+      appstream:
+        keywords:
+          - adaptive
+        name: Komikku
+        summary: Откройте для себя и читайте мангу и комиксы
+        icon: https://apps.gnome.org/icons/scalable/info.febvre.Komikku.svg
+      about_app: https://apps.gnome.org/ru/Komikku/
+    'Letterpress':
+      aggregation:
+        flatpak: io.gitlab.gregorni.Letterpress
+        sisyphus: letterpress
+      appstream:
+        keywords:
+          - adaptive
+        name: Letterpress
+        summary: Создайте красивые ASCII-арты
+        icon: https://apps.gnome.org/icons/scalable/io.gitlab.gregorni.Letterpress.svg
+      about_app: https://apps.gnome.org/ru/Letterpress/
+    'Lorem':
+      aggregation:
+        flatpak: org.gnome.design.Lorem
+      appstream:
+        keywords:
+          - donttheme
+          - adaptive
+        name: Lorem
+        summary: Создание текста-заполнителя
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.design.Lorem.svg
+      about_app: https://apps.gnome.org/ru/Lorem/
+    'Mousai':
+      aggregation:
+        flatpak: io.github.seadve.Mousai
+        sisyphus: mousai
+      appstream:
+        keywords:
+          - adaptive
+        name: Mousai
+        summary: Распознавайте песни за секунды
+        icon: https://apps.gnome.org/icons/scalable/io.github.seadve.Mousai.svg
+      about_app: https://apps.gnome.org/ru/Mousai/
+    'NewsFlash':
+      aggregation:
+        flatpak: io.gitlab.news_flash.NewsFlash
+        sisyphus: newsflash
+      appstream:
+        keywords:
+          - donttheme
+          - adaptive
+        name: NewsFlash
+        summary: Следите за своими каналами
+        icon: https://apps.gnome.org/icons/scalable/io.gitlab.news_flash.NewsFlash.svg
+      about_app: https://apps.gnome.org/ru/NewsFlash/
+    'Obfuscate':
+      aggregation:
+        flatpak: com.belmoussaoui.Obfuscate
+        sisyphus: obfuscate
+      appstream:
+        keywords:
+          - donttheme
+          - adaptive
+        name: Obfuscate
+        summary: Цензор личной информации
+        icon: https://apps.gnome.org/icons/scalable/com.belmoussaoui.Obfuscate.svg
+      about_app: https://apps.gnome.org/ru/Obfuscate/
+    'PdfMetadataEditor':
+      aggregation:
+        flatpak: io.github.diegoivan.pdf_metadata_editor
+      appstream:
+        keywords:
+          - adaptive
+        name: Paper Clip
+        summary: Редактирование метаданных документов PDF
+        icon: https://apps.gnome.org/icons/scalable/io.github.diegoivan.pdf_metadata_editor.svg
+      about_app: https://apps.gnome.org/ru/PdfMetadataEditor/
+    'PikaBackup':
+      aggregation:
+        flatpak: org.gnome.World.PikaBackup
+        sisyphus: pika-backup
+      appstream:
+        keywords:
+          - donttheme
+          - adaptive
+        name: Pika Backup
+        summary: Обеспечьте сохранность своих данных
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.World.PikaBackup.svg
+      about_app: https://apps.gnome.org/ru/PikaBackup/
+    'Polari':
+      aggregation:
+        flatpak: org.gnome.Polari
+        sisyphus: polari
+      appstream:
+        keywords:
+          - adaptive
+        name: Polari
+        summary: Разговор с людьми в IRC
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Polari.svg
+      about_app: https://apps.gnome.org/ru/Polari/
+    'DieBahn':
+      aggregation:
+        flatpak: de.schmidhuberj.DieBahn
+      appstream:
+        keywords:
+          - adaptive
+        name: Railway
+        summary: Найти всю информацию о путешествиях
+        icon: https://apps.gnome.org/icons/scalable/de.schmidhuberj.DieBahn.svg
+      about_app: https://apps.gnome.org/ru/DieBahn/
+    'Secrets':
+      aggregation:
+        flatpak: org.gnome.World.Secrets
+        sisyphus: secrets
+      appstream:
+        keywords:
+          - donttheme
+          - adaptive
+        name: Secrets
+        summary: Управление паролями
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.World.Secrets.svg
+      about_app: https://apps.gnome.org/ru/Secrets/
+    'Shortwave':
+      aggregation:
+        flatpak: de.haeckerfelix.Shortwave
+        sisyphus: shortwave
+      appstream:
+        keywords:
+          - donttheme
+        name: Shortwave
+        summary: Слушайте интернет-радио
+        icon: https://apps.gnome.org/icons/scalable/de.haeckerfelix.Shortwave.svg
+      about_app: https://apps.gnome.org/ru/Shortwave/
+    'Solanum':
+      aggregation:
+        flatpak: org.gnome.Solanum
+        sisyphus: solanum
+      appstream:
+        name: Solanum
+        summary: Баланс рабочего времени и времени перерыва
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Solanum.svg
+      about_app: https://apps.gnome.org/ru/Solanum/
+    'Tangram':
+      aggregation:
+        flatpak: re.sonny.Tangram
+        sisyphus: tangram
+      appstream:
+        keywords:
+          - adaptive
+        name: Tangram
+        summary: Браузер для закреплённых вкладок
+        icon: https://apps.gnome.org/icons/scalable/re.sonny.Tangram.svg
+      about_app: https://apps.gnome.org/ru/Tangram/
+    'TextPieces':
+      aggregation:
+        flatpak: io.gitlab.liferooter.TextPieces
+        sisyphus: textpieces
+      appstream:
+        keywords:
+          - adaptive
+        name: Text Pieces
+        summary: Блокнот разработчика
+        icon: https://apps.gnome.org/icons/scalable/io.gitlab.liferooter.TextPieces.svg
+      about_app: https://apps.gnome.org/ru/TextPieces/
+    'Warp':
+      aggregation:
+        flatpak: app.drey.Warp
+        sisyphus: warp
+      appstream:
+        keywords:
+          - adaptive
+        name: Warp
+        summary: Быстрая и безопасная передача файлов
+        icon: https://apps.gnome.org/icons/scalable/app.drey.Warp.svg
+      about_app: https://apps.gnome.org/ru/Warp/
+    'Workbench':
+      aggregation:
+        flatpak: re.sonny.Workbench
+      appstream:
+        name: Workbench
+        summary: Прототип с использованием технологий GNOME
+        icon: https://apps.gnome.org/icons/scalable/re.sonny.Workbench.svg
+      about_app: https://apps.gnome.org/ru/Workbench/
+  dev:
+    'DconfEditor':
+      aggregation:
+        flatpak: ca.desrt.dconf-editor
+        sisyphus: dconf-editor
+      appstream:
+        name: Редактор Dconf
+        summary: Графический инструмент для редактирования базы данных dconf
+        icon: https://apps.gnome.org/icons/scalable/ca.desrt.dconf-editor.svg
+      about_app: https://apps.gnome.org/ru/DconfEditor/
+    'Builder':
+      aggregation:
+        flatpak: org.gnome.Builder
+        sisyphus: gnome-builder
+      appstream:
+        name: Builder
+        summary: IDE для GNOME
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Builder.svg
+      about_app: https://apps.gnome.org/ru/Builder/
+    'Dspy':
+      aggregation:
+        flatpak: org.gnome.dspy
+        sisyphus: dspy
+      appstream:
+        name: D-Spy
+        summary: Анализ соединений D-Bus
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.dspy.svg
+      about_app: https://apps.gnome.org/ru/Dspy/
+    'Devhelp':
+      aggregation:
+        flatpak: org.gnome.Devhelp
+        sisyphus: devhelp
+      appstream:
+        name: Devhelp
+        summary: Инструмент разработчика для поиска и просмотра документации к API
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Devhelp.svg
+      about_app: https://apps.gnome.org/ru/Devhelp/
+    'Sysprof':
+      aggregation:
+        sisyphus: sysprof
+      appstream:
+        name: Sysprof
+        summary: Профилирование приложения или всей системы
+        icon: https://apps.gnome.org/icons/scalable/org.gnome.Sysprof.svg
+      about_app: https://apps.gnome.org/ru/Sysprof/
+---
+
+# Приложения для GNOME
+
+Все приложения, представленные в этом обзоре, созданы с учётом философии GNOME. Они просты в понимании и использовании, отличаются последовательным и отшлифованным дизайном и заметным вниманием к деталям. Естественно, они являются свободным программным обеспечением и обязуются быть частью гостеприимного и дружелюбного сообщества. Эти приложения идеально впишутся в ваш рабочий стол GNOME.
+
+## Основные приложения
+
+Приложения GNOME Core предназначены для выполнения обычных задач на рабочем столе GNOME. Они обычно предустановлены в вашей системе ALT Regular Gnome.
+
+<GnomeAppsList category="core"/>
+
+## Приложения Circle
+
+GNOME Circle содержит приложения, расширяющие экосистему GNOME. Он олицетворяет отличное дополнительное программное обеспечение, доступное для платформы GNOME
+
+<GnomeAppsList category="circle"/>
+
+## Инструменты для разработки
+
+Инструменты для разработки в среде GNOME помогают разрабатывать и проектировать новые приложения и упрощают внесение вклада в существующие.
+
+<GnomeAppsList category="dev"/>

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "devDependencies": {
     "@nolebase/ui": "^2.2.2",
     "@nolebase/vitepress-plugin-enhanced-readabilities": "^2.2.2",


### PR DESCRIPTION
- Need additional rewrite for `/en/system/apps-gnome/index.md`
(Need to add English names and descriptions)

- Need to double-check all lists of apps.
(It can be less than normal, now it's reuse of list from ALT Gnome Wiki and some apps maybe not in frontmatter, cause they are parsed from wiki)

You can don't merge this PR if needed to end rewrites and checks.